### PR TITLE
Use Unicode directional formatting codes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 The قلب Programming Language
 ===========================
-قلب is a simple, [Scheme-like](http://en.wikipedia.org/wiki/Scheme_language) programming language that you code entirely in [Arabic](http://en.wikipedia.org/wiki/Modern_Standard_Arabic). It is an exploration of the impact of human culture on computer science, the role of tradition in software engineering, and the connection between natural and computer languages.
+‫قلب‬ is a simple, [Scheme-like](http://en.wikipedia.org/wiki/Scheme_language) programming language that you code entirely in [Arabic](http://en.wikipedia.org/wiki/Modern_Standard_Arabic). It is an exploration of the impact of human culture on computer science, the role of tradition in software engineering, and the connection between natural and computer languages.
 
 Syntax
 ------
-قلب has a minimal Scheme-like parenthesized syntax. Note that GitHub's layout engine will mangle all code samples in this Readme.
+‫قلب‬ has a minimal Scheme-like parenthesized syntax.
 
 Hello world looks like this
 
 ```scheme
-(قول "مرحبا يا عالم!")
+‫(قول "مرحبا يا عالم!")
 ```
 
 


### PR DESCRIPTION
It's not github that mangles the code samples in the README—the mix of left-to-right and right-to-left text is enough to confuse a lot of software, and in this case it's the standard Unicode bidirectional algorithm that isn't smart enough to figure out what you wanted. Basically, I think it treats the parentheses and other punctuation as left-to-right by default.

However, Unicode offers a way to specify explicitly that a particular paragraph or word is intended as an island of right-to-left text in an enclosing left-to-right document. This patch does so for a few bits of Arabic in your README.md.

More information here: http://www.unicode.org/reports/tr9/#Directional_Formatting_Codes
