### PR TITLE
README: LTR marks, and minor copyedit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 The قلب Programming Language
 ===========================
-‫قلب‬ is a simple, [Scheme-like](http://en.wikipedia.org/wiki/Scheme_language) programming language that you code entirely in [Arabic](http://en.wikipedia.org/wiki/Modern_Standard_Arabic). It is an exploration of the impact of human culture on computer science, the role of tradition in software engineering, and the connection between natural and computer languages.
+‫&lrm;قلب‬ is a simple, [Scheme-like](http://en.wikipedia.org/wiki/Scheme_language) programming language
+that you code entirely in [Arabic](http://en.wikipedia.org/wiki/Modern_Standard_Arabic). It is an
+exploration of the impact of human culture on computer science, the role of tradition in software
+engineering, and the connection between natural and computer languages.
 
 Syntax
 ------
-‫قلب‬ has a minimal Scheme-like parenthesized syntax.
+‫&lrm;قلب‬ has a minimal Scheme-like parenthesized syntax.
 
-Hello world looks like this
+Hello World looks like this:
 
 ```scheme
 ‫(قول "مرحبا يا عالم!")
@@ -15,26 +18,27 @@ Hello world looks like this
 
 Name
 ----
-قلب is pronounced 'alb and means "heart" in Arabic. It is a recursive acronym standing for قلب: لغة برمجة, pronounced 'alb: lughat barmajeh, meaning "'alb: a programming language."
+&lrm;قلب is pronounced *'alb* and means "heart" in Arabic. It is a recursive acronym standing for قلب: لغة برمجة,
+pronounced *'alb: lughat barmajeh*, meaning "*'alb*: a programming language."
 
 Acknowledgments
 ---------------
-The implementation is largely based on [Lispy, Peter Norvig's 90 line Lisp interpreter](http://norvig.com/lispy.html)
+The implementation is largely based on [Lispy, Peter Norvig's 90 line Lisp interpreter](http://norvig.com/lispy.html).
 
-The REPL and Editor are built on [jq-console](http://replit.github.com/jq-console/), by [Max Shawabkeh](http://max99x.com/) and [Amjad Masad](http://twitter.com/amjad_masad)
+The REPL and Editor are built on [jq-console](http://replit.github.com/jq-console/), by [Max Shawabkeh](http://max99x.com/) and [Amjad Masad](http://twitter.com/amjad_masad).
 
-The parser is built using [Peg.js](http://pegjs.majda.cz/), &copy; 2010-2012 David Majda
+The parser is built using [Peg.js](http://pegjs.majda.cz/), &copy; 2010-2012 David Majda.
 
 The implementation of the Fibonacci algorithm is based on [this one](http://rosettacode.org/wiki/Fibonacci_sequence#Scheme) from [Rosetta Code](http://rosettacode.org/).
 
 The implementation of Conway's Game of Life is based on [this one](http://rosettacode.org/wiki/Conway%27s_Game_of_Life#Scheme) from [Rosetta Code](http://rosettacode.org/).
 
-Arabic spelling and grammar help from the wonderful [Haitham Ennasr](https://twitter.com/e_n_n_a_s_r)
+Arabic spelling and grammar help from the wonderful [Haitham Ennasr](https://twitter.com/e_n_n_a_s_r).
 
-Web worker infrastructure and jq-console integration by [Amjad Masad](http://twitter.com/amjad_masad)
+Web worker infrastructure and jq-console integration by [Amjad Masad](http://twitter.com/amjad_masad).
 
 Legal
 -----
 Copyright &copy; Ramsey Nasser 2012, provided under the [MIT License](http://opensource.org/licenses/MIT).
 
-Developed at [Eyebeam](http://eyebeam.org/) as part of my fellowship exploring code as a medium of self expression.
+Developed at [Eyebeam](http://eyebeam.org/) as part of my fellowship exploring code as a medium of self-expression.


### PR DESCRIPTION
Compare the rendering [before](https://github.com/nasser/---/tree/master?tab=readme-ov-file#the-%D9%82%D9%84%D8%A8-programming-language) versus [after](https://github.com/Quuxplusone/nasser-qalb/tree/unicode?tab=readme-ov-file#the-%D9%82%D9%84%D8%A8-programming-language).

Interestingly, GitHub seems to screw up the rendering of the first two paragraphs of the diff — probably because in both cases it's trying to diff a (formerly) RTL paragraph against a (newly) LTR paragraph.